### PR TITLE
Fix potential UB in `Variable::kind()` method

### DIFF
--- a/relations/src/utils/variable.rs
+++ b/relations/src/utils/variable.rs
@@ -130,13 +130,15 @@ impl Variable {
     #[inline(always)]
     #[allow(unsafe_code)]
     pub const fn kind(self) -> VarKind {
-        match self.tag() {
+        let tag = self.tag();
+        debug_assert!(tag <= 4);
+        match tag {
             0 => VarKind::Zero,
             1 => VarKind::One,
             2 => VarKind::Instance,
             3 => VarKind::Witness,
             4 => VarKind::SymbolicLc,
-            _ => unsafe { core::hint::unreachable_unchecked() },
+            _ => VarKind::SymbolicLc,
         }
     }
 


### PR DESCRIPTION


### Description
Replaces `unsafe { unreachable_unchecked() }` with a safe fallback in `Variable::kind()` to prevent undefined behavior when encountering invalid variable tags.

### Changes
-  Added `debug_assert!(tag <= 4)` to catch invalid tags in debug builds
-  Replaced UB-prone `unreachable_unchecked()` with safe default return
-  Preserved `const fn` signature and performance characteristics

