### PR TITLE
Fix potential panic in ConstraintTrace display formatting

### DIFF
--- a/relations/src/gr1cs/trace.rs
+++ b/relations/src/gr1cs/trace.rs
@@ -307,7 +307,7 @@ impl fmt::Display for ConstraintTrace {
                     f,
                     "{:>4}: {}::{}",
                     span,
-                    metadata.module_path().unwrap(),
+                    metadata.module_path().unwrap_or(metadata.target()),
                     metadata.name()
                 ),
                 err


### PR DESCRIPTION


## Problem
The `fmt::Display` implementation for `ConstraintTrace` used `metadata.module_path().unwrap()`, which could panic if the module path is not available for certain spans (e.g., from macros or external sources).

## Solution
Replace `unwrap()` with `unwrap_or(metadata.target())` to provide a safe fallback using the span's target as an alternative identifier.

## Changes
- **File**: `relations/src/gr1cs/trace.rs`
- **Line**: 310
- **Before**: `metadata.module_path().unwrap()`
- **After**: `metadata.module_path().unwrap_or(metadata.target())`

